### PR TITLE
update dependencies to fix several vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
   "devDependencies": {
     "buffered-spawn": "~1.1.2",
     "chai": "~3.3.0",
-    "foundry": "~4.0.4",
+    "foundry": "~4.6.0",
     "foundry-release-git": "~2.0.2",
     "foundry-release-npm": "~2.0.2",
     "jscs": "~1.7.3",
-    "jshint": "~2.5.10",
-    "mocha": "~2.3.3",
+    "jshint": "~2.13.4",
+    "mocha": "~8.4.0",
     "twolfson-style": "~1.6.0"
   },
   "keywords": [


### PR DESCRIPTION
There are too many vulernabilities to mention and link each of them separately.


Note that the CI may fail with a message like:
```
> foundry-release-base@1.0.2 lint /home/user/git-repos/foundry-release-base
> twolfson-style lint lib/ test/

fs.js:40
} = primordials;
    ^

ReferenceError: primordials is not defined
    at fs.js:40:5
    at req_ (/home/dirk/git-repos/foundry-release-base/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/home/user/git-repos/foundry-release-base/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/home/user/git-repos/foundry-release-base/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! foundry-release-base@1.0.2 lint: `twolfson-style lint lib/ test/`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the foundry-release-base@1.0.2 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

This also happens to me on Node 14 before the patch, so it's not introduced by the patch. An [answer on StackOverflow](https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node-js/58394828#58394828) to a similar problem suggests that this happens with certain newer Node.js versions. However, such versions seem not to be tested on the current CI settings, so it may possibly pass without such an error. On the other hand, there may be different errors due to the tested Node.js versions being rather old.